### PR TITLE
feat: containerize chroma db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 test_nginx/
 embedding_model/
 models/
+chroma-data/

--- a/helm/templates/RAG.yaml
+++ b/helm/templates/RAG.yaml
@@ -32,6 +32,8 @@ spec:
           value: /embedding_model
         - name: LLM_API_BASE
           value: http://llm-service.default:8000/v1
+        - name: CHROMADB_HOST
+          value: vectorstore-service.default
         - name: MODEL_NAME
           value: /EEVE-Korean-Instruct-10.8B-v1.0-quantized
         volumeMounts:

--- a/helm/templates/VectorStore-service.yaml
+++ b/helm/templates/VectorStore-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vectorstore-service
+spec:
+  selector:
+    app: vectorstore
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/helm/templates/VectorStore.yaml
+++ b/helm/templates/VectorStore.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vectorstore-deployment
+  labels:
+    app: vectorstore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vectorstore
+  template:
+    metadata:
+      labels:
+        app: vectorstore
+    spec:
+      containers:
+      - name: vectorstore
+        image: chromadb/chroma
+        ports:
+        - containerPort: 8000
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: "1"
+          limits:
+            memory: 2Gi
+            cpu: "2"
+        env:
+        - name: IS_PERSISTENT
+          value: "TRUE"
+        - name: ALLOW_RESET
+          value: "TRUE"
+        volumeMounts:
+        - mountPath: /chroma/chroma
+          name: chroma-data
+      volumes:
+      - name: chroma-data
+        hostPath:
+          type: Directory
+          path: {{ .Values.vectorstore_data_path }}
+    
+    

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,7 @@
 LLM_path: /AiChatbot_RobotClub/models/EEVE-Korean-Instruct-10.8B-v1.0-quantized
 embedding_model_path: /AiChatbot_RobotClub/models/embedding_model
 
-rag_src_path: /AiChatbot_RobotClub/src_test/rag
-kakao_src_path: /AiChatbot_RobotClub/src_test/kakao
+rag_src_path: /AiChatbot_RobotClub/src/rag
+kakao_src_path: /AiChatbot_RobotClub/src/kakao
+
+vectorstore_data_path: /AiChatbot_RobotClub/chroma-data

--- a/src/rag/main.py
+++ b/src/rag/main.py
@@ -2,6 +2,9 @@ import os
 
 import uvicorn
 from fastapi import FastAPI
+import chromadb
+from chromadb.config import Settings
+
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
@@ -16,13 +19,19 @@ from schemas import Request, Response
 
 EMBEDDING_MODEL = os.environ["EMBEDDING_MODEL"]
 LLM_API_BASE = os.environ["LLM_API_BASE"]
+CHROMADB_HOST = os.environ["CHROMADB_HOST"]
 MODEL_NAME = os.environ["MODEL_NAME"]
-
 
 embeddings = HuggingFaceEmbeddings(
     model_name="jhgan/ko-sroberta-multitask", cache_folder=EMBEDDING_MODEL
 )
-vectorstore = Chroma(embedding_function=embeddings)
+
+client = chromadb.HttpClient(host=CHROMADB_HOST, settings=Settings(allow_reset=True))
+vectorstore = Chroma(
+    client=client,
+    collection_name="my_collection",
+    embedding_function=embeddings,
+)
 retriever = vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 3})
 
 prompt_rag = PromptTemplate.from_template(TEMPLATE_RAG)


### PR DESCRIPTION
## Chroma vector store
### 이전
- RAG pipeline server에서 in-memory mode로 사용
### 이번
- vectorstore pod를 분리해서 구성후 RAG server에서 client로 연결
```YAML
# VectorStore.yaml
containers:
- name: vectorstore
  image: chromadb/chroma
  ports:
  - containerPort: 8000
  resources:
    requests:
      memory: 1Gi
      cpu: "1"
    limits:
      memory: 2Gi
      cpu: "2"
  env:
  - name: IS_PERSISTENT
    value: "TRUE"
  - name: ALLOW_RESET
    value: "TRUE"
  volumeMounts:
  - mountPath: /chroma/chroma
    name: chroma-data
```
### Architecture
![chatbot_robotclub drawio](https://github.com/sinjy1203/AiChatbot_RobotClub/assets/52316531/748bdfc7-f61a-47ee-ac95-111433e6eb4a)

